### PR TITLE
Add a Mobile and Native section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A curated list of awesome things related to Vue 3
   - [Articles](#articles)
   - [Packages](#packages)
     - [Form editor](#form-editor)
+  - [Mobile and Native](#mobile-and-native)
   - [Examples](#examples)
   - [Tools](#tools)
   - [Videos](#videos)
@@ -231,6 +232,21 @@ A curated list of awesome things related to Vue 3
 #### Form editor
 
 - [Everright-formEditor](https://github.com/Liberty-liu/Everright-formEditor) - A visual drag-and-drop low-code form editor. The PC depends on element-plus while the mobile depends on vant.
+
+## Mobile and Native
+
+_Frameworks_
+
+- [Vue Lynx](https://vue.lynxjs.org) - A Vue 3 custom renderer for [Lynx](https://lynxjs.org), rendering to native iOS and Android views and compiling to web from one codebase.
+- [Ionic Vue](https://ionicframework.com/docs/vue/overview) - The Vue 3 build of Ionic, packaging a web app as an iOS, Android or PWA target through Capacitor.
+- [NativeScript-Vue](https://nativescript-vue.org/) - Native iOS and Android applications written in Vue, rendering platform widgets instead of a web view.
+- [Quasar](https://quasar.dev/) - A Vue 3 framework that builds one codebase into SPA, PWA, Electron, Capacitor and Cordova targets.
+- [Taro](https://taro.zone/) - A cross-platform framework with Vue 3 support, compiling to HarmonyOS, React Native, web and the mini-program platforms.
+- [uni-app](https://uniapp.dcloud.net.cn/) - A Vue 3 framework that compiles to iOS, Android, web and the mini-program platforms.
+
+_Component libraries_
+
+- [Vy UI](https://vyui.dev) - Headless primitives and styled components for Vue Lynx, with a shadcn-style CLI for copying component source into your project.
 
 ## Examples
 


### PR DESCRIPTION
The list has nowhere to put Vue 3 running outside the browser at the moment, so the frameworks that render to native views or package as mobile apps are either scattered through Packages or missing altogether. I added a Mobile and Native section between Packages and Examples, with the matching table of contents entry, split into frameworks and component libraries the way awesome-vue groups its own mobile section.

- **Vue Lynx** leads the frameworks group. It is the Vue 3 custom renderer for [Lynx](https://lynxjs.org), which renders native iOS and Android views, and the list does not mention Lynx anywhere today.
- **Ionic Vue, NativeScript-Vue, Quasar, Taro and uni-app** fill in the established options, none of which appear in the list either. Taro is there because it supports Vue 3 alongside React and reaches HarmonyOS through `@tarojs/plugin-platform-harmony-ets`.
- **Vy UI** sits in its own component libraries group at the end, as the library built on Vue Lynx.

I left hy-app where it is in Packages rather than move someone else's entry, though it is a UniApp component library and would sit naturally in the new section if you want it there.

Disclosure: I maintain Vy UI, which is MIT licensed and published on npm. If you would rather the section stayed to more established projects, I am happy to drop that entry and keep the rest.